### PR TITLE
Fix plugin failing build when tests only contain inconclusive/skipped…

### DIFF
--- a/src/main/java/hudson/plugins/mstest/MSTestPublisher.java
+++ b/src/main/java/hudson/plugins/mstest/MSTestPublisher.java
@@ -183,7 +183,7 @@ public class MSTestPublisher extends Recorder implements Serializable {
                 action = existingAction;
                 action.setResult(result, (TaskListener)listener);
             }
-            if (result.getPassCount() == 0 && result.getFailCount() == 0) {
+            if (result.isEmpty()) {
                 throw new AbortException("[MSTEST-PLUGIN] None of the test reports contained any result.");
             }
         } catch (AbortException e) {


### PR DESCRIPTION
Fix plugin failing build when tests only contain inconclusive/skipped tests. Previously it only checked if there were passing and failing tests.