### PR TITLE
Fix CVE-2023-24441 preventing XXE attacks

### DIFF
--- a/src/main/java/hudson/plugins/mstest/MSTestReportConverter.java
+++ b/src/main/java/hudson/plugins/mstest/MSTestReportConverter.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -113,6 +114,14 @@ class MSTestReportConverter implements Serializable {
     private boolean containsData(File c) throws IOException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         try {
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(c);
             XPathFactory xPathfactory = XPathFactory.newInstance();
@@ -148,6 +157,12 @@ class MSTestReportConverter implements Serializable {
         throws TransformerFactoryConfigurationError,
         ParserConfigurationException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         return factory.newDocumentBuilder();
     }
 

--- a/src/main/java/hudson/plugins/mstest/XslTransformer.java
+++ b/src/main/java/hudson/plugins/mstest/XslTransformer.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -22,12 +23,16 @@ class XslTransformer {
     XslTransformer()
         throws TransformerConfigurationException {
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         xslTransformer = transformerFactory.newTransformer();
     }
 
     private XslTransformer(String xslTransform)
         throws TransformerConfigurationException {
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         xslTransformer = transformerFactory
             .newTransformer(new StreamSource(this.getClass().getResourceAsStream(xslTransform)));
     }

--- a/src/test/java/hudson/plugins/mstest/MSTestReportConverterTest.java
+++ b/src/test/java/hudson/plugins/mstest/MSTestReportConverterTest.java
@@ -4,6 +4,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
@@ -29,10 +32,19 @@ import static org.junit.Assert.assertTrue;
 public class MSTestReportConverterTest {
 
     @Before
-    public void setUp() {
+    public void setUp() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+
         XMLUnit.setIgnoreWhitespace(true);
         XMLUnit.setNormalizeWhitespace(true);
         XMLUnit.setIgnoreComments(true);
+        XMLUnit.setControlDocumentBuilderFactory(factory);
     }
 
     @Test


### PR DESCRIPTION
This PR introduces XML parser and transformer configuration that should prevent XXE attacks (per security vulnerability described [here](https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2292)).