### PR TITLE
Fix default logging level

### DIFF
--- a/src/main/java/hudson/plugins/mstest/MsTestLogger.java
+++ b/src/main/java/hudson/plugins/mstest/MsTestLogger.java
@@ -20,7 +20,8 @@ class MsTestLogger implements Serializable {
 
     MsTestLogger(TaskListener listener) {
         this.listener = listener;
-        this.configuredLevel = parseLevel(System.getProperty(HUDSON_PLUGINS_MSTEST_LEVEL));
+        String mstestLevel = System.getProperty(HUDSON_PLUGINS_MSTEST_LEVEL);
+        this.configuredLevel = parseLevel(mstestLevel != null ? mstestLevel : MSTestPublisher.DescriptorImpl.defaultLogLevel);
     }
 
     static MsTestLogger getLogger() {
@@ -45,6 +46,10 @@ class MsTestLogger implements Serializable {
 
     void error(String format, Object... args) {
         printf(Level.SEVERE, format, args);
+    }
+
+    Level getConfiguredLogLevel() {
+        return configuredLevel;
     }
 
     private void printf(Level level, String format, Object... args) {

--- a/src/test/java/hudson/plugins/mstest/MsTestLoggerTest.java
+++ b/src/test/java/hudson/plugins/mstest/MsTestLoggerTest.java
@@ -1,0 +1,45 @@
+package hudson.plugins.mstest;
+
+import java.util.logging.Level;
+import org.junit.Test;
+import hudson.plugins.mstest.MsTestLogger;
+
+import static org.junit.Assert.assertTrue;
+
+public class MsTestLoggerTest {
+
+    @Test
+    public void testConstructor() {
+        // arrange
+        System.clearProperty(MsTestLogger.HUDSON_PLUGINS_MSTEST_LEVEL);
+
+        // act
+        MsTestLogger logger = new MsTestLogger(null);
+
+        // assert
+        Level logLevel = logger.getConfiguredLogLevel();
+        assertTrue(logLevel == Level.INFO);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testConstructorShouldThrowExceptionWhenUnknownLevel() {
+        // arrange
+        System.setProperty(MsTestLogger.HUDSON_PLUGINS_MSTEST_LEVEL, "INVALID_LEVEL");
+
+        // act
+        MsTestLogger logger = new MsTestLogger(null);
+    }
+
+    @Test
+    public void testConstructorShouldParseLogLevel() {
+        // arrange
+        System.setProperty(MsTestLogger.HUDSON_PLUGINS_MSTEST_LEVEL, "WARNING");
+
+        // act
+        MsTestLogger logger = new MsTestLogger(null);
+
+        // assert
+        Level logLevel = logger.getConfiguredLogLevel();
+        assertTrue(logLevel == Level.WARNING);
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This bug has prevented us from upgrading the plugin in the production. We have temporarily rolled back.
The problem was introduced with the commit https://github.com/jenkinsci/mstest-plugin/commit/0bc647db6f471a379ab6bcc47a896622eb81c901#diff-bfa7db31ab2e96ea4613616500a06879b44120fd13c6fe701d23744dc823d57dR81

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

## Expected behavior
- The log level should use the default log level, when the publish functionality is not used.

## Actual behavior
<ul>
<li>The <code>MsTestLogger</code> class  will throw a <code>RuntimeException</code>, when publish is not executed before:

```
Dotnet test: Unknown [null] level provided!
[hudson.plugins.mstest.MsTestLogger.parseLevel(MsTestLogger.java:81), hudson.plugins.mstest.MsTestLogger.<init>(MsTestLogger.java:23), hudson.plugins.mstest.MSTestTransformer.invoke(MSTestTransformer.java:51), hudson.plugins.mstest.MSTestTransformer.invoke(MSTestTransformer.java:22), hudson.FilePath$FileCallableWrapper.call(FilePath.java:3578), hudson.remoting.UserRequest.perform(UserRequest.java:211), hudson.remoting.UserRequest.perform(UserRequest.java:54), hudson.remoting.Request$2.run(Request.java:377), hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78), java.base/java.util.concurrent.FutureTask.run(Unknown Source), java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source), java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source), hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:125), java.base/java.lang.Thread.run(Unknown Source)]
```

</li>
<li>The Jenkins Pipeline will fail with <code>Dotnet test: Unknown [null] level provided!</code>.</li>
</ul>

## Changes
- Added unit tests to check, if the log level is set correctly
- Fixed the bug, by falling back to the default log level (``INFO``) when the property is not set.
