### PR TITLE
prevention of race conditions if used in a pipeline with parallel

### DIFF
--- a/src/main/java/hudson/plugins/mstest/MSTestPublisher.java
+++ b/src/main/java/hudson/plugins/mstest/MSTestPublisher.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.UUID;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.tasks.SimpleBuildStep;
 import org.apache.tools.ant.DirectoryScanner;
@@ -141,17 +142,18 @@ public class MSTestPublisher extends Recorder implements Serializable, SimpleBui
 
         buildTime = build.getTimestamp().getTimeInMillis();
 
+        String junitReportDir = MSTestTransformer.JUNIT_REPORTS_PATH_DIR_PREFIX + "-" + UUID.randomUUID();
         String[] matchingFiles = resolveTestReports(testResultsFile, build, workspace, listener);
         MSTestReportConverter converter = new MSTestReportConverter(listener);
         MSTestTransformer transformer = new MSTestTransformer(matchingFiles, converter, listener,
-            failOnError);
+            failOnError, junitReportDir);
         boolean result = workspace.act(transformer);
 
         if (result) {
             // Run the JUnit test archiver
-            recordTestResult(MSTestTransformer.JUNIT_REPORTS_PATH + "/TEST-*.xml", build, workspace,
-                listener);
-            workspace.child(MSTestTransformer.JUNIT_REPORTS_PATH).deleteRecursive();
+            recordTestResult(junitReportDir + "/TEST-*.xml", build, workspace,
+                    listener);
+            workspace.child(junitReportDir).deleteRecursive();
         } else {
             throw new AbortException("Unable to transform the MSTest report.");
         }

--- a/src/main/java/hudson/plugins/mstest/MSTestTransformer.java
+++ b/src/main/java/hudson/plugins/mstest/MSTestTransformer.java
@@ -21,20 +21,27 @@ import org.xml.sax.SAXException;
  */
 public class MSTestTransformer extends MasterToSlaveFileCallable<Boolean> {
 
-    static final String JUNIT_REPORTS_PATH = "temporary-junit-reports";
+    static final String JUNIT_REPORTS_PATH_DIR_PREFIX = "temp-junit-reports";
     private static final long serialVersionUID = 1L;
     private final TaskListener listener;
     private final boolean failOnError;
+    private final String junitReportDir;
 
     private final MSTestReportConverter unitReportTransformer;
     private final String[] msTestFiles;
 
     MSTestTransformer(String[] msTestFiles, @NonNull MSTestReportConverter unitReportTransformer,
         @NonNull TaskListener listener, boolean failOnError) {
+        this(msTestFiles, unitReportTransformer, listener, failOnError, null);
+    }
+
+    MSTestTransformer(String[] msTestFiles, @NonNull MSTestReportConverter unitReportTransformer,
+        @NonNull TaskListener listener, boolean failOnError, String junitReportDir) {
         this.msTestFiles = msTestFiles;
         this.unitReportTransformer = unitReportTransformer;
         this.listener = listener;
         this.failOnError = failOnError;
+        this.junitReportDir = (junitReportDir != null) ? junitReportDir : JUNIT_REPORTS_PATH_DIR_PREFIX; // Keep tests calls simple
     }
 
     /**
@@ -59,7 +66,7 @@ public class MSTestTransformer extends MasterToSlaveFileCallable<Boolean> {
                 .format("No MSTest TRX test report files were found. Configuration error?"));
         }
 
-        File junitOutputPath = new File(ws, JUNIT_REPORTS_PATH);
+        File junitOutputPath = new File(ws, junitReportDir);
         boolean success = FileOperator.safeCreateFolder(junitOutputPath, logger);
         if (!success) {
             return Boolean.FALSE;


### PR DESCRIPTION
Problem and solution is described in the following issue: [Race conditions in Jenkins pipeline with parallel mstest execution #29](https://github.com/jenkinsci/mstest-plugin/issues/29)

### Testing done
All unit tests are successful. We are using the new version of the plugin in production without any problems.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue